### PR TITLE
fixed creation of where clause in translateJoin

### DIFF
--- a/findComplex.js
+++ b/findComplex.js
@@ -486,12 +486,14 @@ findComplex.prototype.translateJoin = function(join,method='LATERAL',parentJoin,
             +tmpParentJoin.alias+"."+tmpJoin.relationData.keyFrom;
           }
 
-          if(closeJoin.where != null){
+          // TODO: The following parentJoin.where replaces former closeJoin.where. Check if works correctly.
+          if(parentJoin.where != null){
             mainQuery.sql = mainQuery.sql + " AND ";
-            mainQuery = mainQuery.merge(closeJoin.where,"");
+            mainQuery = mainQuery.merge(parentJoin.where,"");
           }
         }
         else{
+          // TODO: Check if the following closeJoin.where should also be changed to parentJoin.where.
           if(closeJoin.where != null){
             mainQuery.sql = mainQuery.sql + " WHERE ";
             mainQuery = mainQuery.merge(closeJoin.where,"");


### PR DESCRIPTION
**Problem**
When adding a where condition on $relation of a certain depth (zero based level 2 and deeper), the wrong where clause is used to close the join.

Steps to reproduce: Create a filter definition with at least 3 nested relations and add a where clause to the innermost child of the filter. This should then lead to an error like "column [child_table].[column used in where clause] does not exist"

**Solution**
Use the parentJoin.where instead of closeJoin.where in translateJoin().

https://github.com/kleiolab/findComplex/blob/3d9a3d48df3071675f11443f36b00db149e21170/findComplex.js#L489-L501

**Remark**
Since I don't understand the full complexity of the library, I'm not sure if this PR really solves this problem. There are two comment in the changed code section. 
Can you please review this @tellex ?
That would be wonderful! Thanks